### PR TITLE
drawCircle and getColor added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# VIM temp files
+*.swp
+
+# Linux ctags
+tags

--- a/Piccolino_OLED.cpp
+++ b/Piccolino_OLED.cpp
@@ -232,6 +232,7 @@ void Piccolino_OLED::updateRow(int startID, int endID)
   }
 }
 
+
 // Original concept borrowed from Adafruit's GFX library modified for Piccolino by AS
 void Piccolino_OLED::drawPixel(int16_t x, int16_t y, uint16_t color)
 {
@@ -371,6 +372,64 @@ void Piccolino_OLED::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, ui
     if (err < 0) {
       y0 += ystep;
       err += dx;
+    }
+  }
+}
+
+/**
+ * Get the color that should be used
+ *
+ * This function is to deal with Gray since every other pixel is printed
+ *
+ * @param color The color that is requested
+ * @param index Current index of the pixel that is to be printed
+ * @return The color to be used
+ */
+uint16_t Piccolino_OLED::getColor(uint16_t color, uint32_t index)
+{
+  if(color == GRAY) {
+    return !(index % 2);
+  }
+  return color;
+}
+
+/**
+ * Draw a circle with an option to fill it
+ *
+ * NOTE: The caller must call the display update function
+ * in order for the circle to be displayed.
+ *
+ * @param cx The center of the circle - X
+ * @param cy The center of the circle - Y
+ * @param radius The radius of the circle
+ * @param color The color of the circle and fill if applicable
+ * @param fill Whether to fill the circle
+ */
+void Piccolino_OLED::drawCircle(
+  int16_t cx, int16_t cy, int16_t radius,
+  uint16_t color, bool fill)
+{
+  int deg;
+  double px, py;
+  uint16_t cur_color;
+  for(deg = 0; deg < 360; deg++) {
+    px = cx + (cos(deg) * radius);
+    py = cy + (sin(deg) * radius);
+    cur_color = getColor(color, deg);
+    drawPixel(px, py, cur_color);
+
+    // Filling
+    if(fill) {
+      int ix;
+      if(px >= cx) {
+        for(ix = cx; ix < px; ix++) {
+          drawPixel(ix, py, cur_color);
+        }
+      } else {
+        for(ix = cx; ix > px; ix--) {
+          drawPixel(ix, py, cur_color);
+        }
+      }
     }
   }
 }

--- a/Piccolino_OLED.h
+++ b/Piccolino_OLED.h
@@ -88,6 +88,9 @@ public:
   void displayOFF();
   void displayON();
   void dim(bool how);
+  uint16_t getColor(uint16_t color, uint32_t index);
+  void drawCircle(int16_t cx, int16_t cy, int16_t radius,
+                  uint16_t color, bool fill);
 
 protected:
   uint8_t _i2caddr;


### PR DESCRIPTION
drawCircle allows the caller to draw a circle of the color that they
specify as well as whether the circle should be filled.

getColor retrieves the color that should be used based on the color that
is requested and the index of the current pixel to draw. This matches
what drawLine uses where even indeces are shown as WHITE for the color
GRAY

A basic example:
display.drawCircle(20, 25, 5, WHITE, true);
display.update();

Also updated .gitignore to include VIM temp files and tags file which should be ignored.
