### PR TITLE
Ability to specify whether to use local or SRAM

### DIFF
--- a/Piccolino_OLED.h
+++ b/Piccolino_OLED.h
@@ -52,18 +52,31 @@
 #define ON    1
 #define OFF   0
 
+#define BUFFER_SIZE 1024
+#define TMP_BUFFER_SIZE 128
+
 class Piccolino_OLED : public Print  {
 public:
 
   Piccolino_OLED();
   ~Piccolino_OLED();
 
-  void begin(uint8_t switchvcc = SSD1306_SWITCHCAPVCC, uint8_t i2caddr = SSD1306_I2C_ADDRESS);
+  // Video Buffer
+  byte *buff;
+
+  // LCD Size
+  uint16_t width = SSD1306_LCDWIDTH;
+  uint16_t height = SSD1306_LCDHEIGHT;
+
+  void begin(bool use_sram = false);
+  void begin_sram();
+  void setVss(uint8_t vss);
+  void setI2CAddr(uint8_t i2caddr);
   void ssd1306_command(uint8_t c);
   void ssd1306_data(uint8_t c);
 
   void invertDisplay(uint8_t i);
-  
+
   void update();
   void clearBuffer();
 
@@ -84,7 +97,7 @@ public:
   virtual size_t write(uint8_t);
   void updateRow(int rowID);
   void updateRow(int startID, int endID);
-  byte buff[1024]; // video buffer
+  //byte buff[1024]; // video buffer
   void displayOFF();
   void displayON();
   void dim(bool how);
@@ -93,10 +106,11 @@ public:
                   uint16_t color, bool fill);
 
 protected:
-  uint8_t _i2caddr;
-    int16_t cursor_x, cursor_y, textcolor, textbgcolor;
-    uint8_t textsize;
-    boolean  wrap; // If set, 'wrap' text at right edge of display
+  uint8_t _i2caddr, _switchvss;
+  int16_t cursor_x, cursor_y, textcolor, textbgcolor;
+  uint8_t textsize;
+  boolean sram; /**< Whether using SRAM or not */
+  boolean  wrap; // If set, 'wrap' text at right edge of display
 
 private:
   int8_t sclk, dc, rst, cs;

--- a/examples/circles/circles.ino
+++ b/examples/circles/circles.ino
@@ -1,0 +1,33 @@
+// For the OLED, we need I2C
+#include <Wire.h>
+
+// For the FRAM we need SPI
+#include <SPI.h>
+
+// I2C OLED library
+#include <Piccolino_OLED.h>
+
+// Piccolino RAM library
+#include <Piccolino_RAM.h>
+
+Piccolino_OLED display; // our OLED object ...
+
+void setup() {
+  // This will use local memory and should look faster
+  display.begin();
+
+  // This will use SRAM and only 128 byte of local memory
+  // Try this out by commenting out the display.begin() and
+  // uncommenting display.begin_sram().
+  //display.begin_sram();
+}
+
+void loop() {
+  display.clear();
+  int cx = 20 + rand() % (display.width / 2);
+  int cy = 5 + rand() % (display.height / 2);
+  int radius = rand() % 20;
+  int bg = rand() % 2;
+  display.drawCircle(cx, cy, radius, WHITE, bg);
+  display.update();
+}


### PR DESCRIPTION
With this commit the Piccolino_OLED_SRAM becomes not necessary
## NOTE:
- Since this is a library that would be widely used this should go into a separate branch until more testing is done to verify its behaviour besides myself, then it can me merged in with master.
- Arduino IDE includes will need the Piccolino_RAM and WPI includes in a project whether or not the SRAM is used.
## Changes:
- Caller can specify whether to use local memory or SRAM during the
  begin call.
- Depending on SRAM a buffer is allocated to either 1K or 128 bytes
- Put all the default settings into the ocnstructor of the object
  instead of them being in the begin
- Added a random circle example where the user can see the difference
  between SRAM and local memory
